### PR TITLE
Refactor to accept object from pipeline and also ensure valid filesystem FilePath for output.

### DIFF
--- a/docs/Out-JsonFile.md
+++ b/docs/Out-JsonFile.md
@@ -13,7 +13,8 @@ Convert an object to JSON and write to a file.
 ## SYNTAX
 
 ```
-Out-JsonFile [-Object] <Object> [[-Path] <String>] [<CommonParameters>]
+Out-JsonFile [-Object] <Object> [[-FilePath] <String>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -25,15 +26,31 @@ file with the name of the object that you provided to the function.
 
 ### EXAMPLE 1
 ```
+Out-JsonFile -Object $TestObject -FilePath $HOME
+```
+
+Writes $TestObject as JSON to "$HOME/TestObject.json".
+
+### EXAMPLE 2
+```
+Out-JsonFile -Object $TestObject -FilePath C:\Temp\report.json
+```
+
+Writes $TestObject as JSON to C:\Temp\report.json.
+
+### EXAMPLE 3
+```
 Out-JsonFile -Object $TestObject
 ```
 
-Writes the $TestObject as JSON to 'TestObject.json'.
+Writes $TestObject as JSON to TestObject.json in the current working directory of the file system.
 
 ## PARAMETERS
 
 ### -Object
-Object to convert to JSON and save to a file
+Object to convert to JSON and save it to a file.
+Check for empty objects here or in the function body?
+\[ValidateScript({ if (-not \[string\]::IsNullOrWhiteSpace($_) -and -not \[string\]::IsNullOrEmpty($_)) { $true } })\]
 
 ```yaml
 Type: Object
@@ -43,12 +60,12 @@ Aliases:
 Required: True
 Position: 1
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Path
-Path to save files in
+### -FilePath
+Full path and filename to save the JSON to.
 
 ```yaml
 Type: String
@@ -57,7 +74,7 @@ Aliases:
 
 Required: False
 Position: 2
-Default value: $PWD
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -72,11 +89,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 Author: Sam Erde
-Version: 0.0.1
-Modified: 2024/10/10
-
-To-Do:
-    Add error handling for objects that cannot be converted to JSON.
-    Validate JSON?
+Version: 0.2.0
+Modified: 2024/10/15
 
 ## RELATED LINKS

--- a/src/PSPreworkout/Public/Out-JsonFile.ps1
+++ b/src/PSPreworkout/Public/Out-JsonFile.ps1
@@ -8,33 +8,77 @@ function Out-JsonFile {
         file with the name of the object that you provided to the function.
 
     .EXAMPLE
+        Out-JsonFile -Object $TestObject -FilePath $HOME
+
+        Writes $TestObject as JSON to "$HOME/TestObject.json".
+
+    .EXAMPLE
+        Out-JsonFile -Object $TestObject -FilePath C:\Temp\report.json
+
+        Writes $TestObject as JSON to C:\Temp\report.json.
+
+    .EXAMPLE
         Out-JsonFile -Object $TestObject
 
-        Writes the $TestObject as JSON to 'TestObject.json'.
+        Writes $TestObject as JSON to TestObject.json in the current working directory of the file system.
 
     .NOTES
         Author: Sam Erde
-        Version: 0.0.1
-        Modified: 2024/10/10
-
-        To-Do:
-            Add error handling for objects that cannot be converted to JSON.
-            Validate JSON?
+        Version: 0.2.0
+        Modified: 2024/10/15
     #>
     [CmdletBinding()]
     param (
-        # Object to convert to JSON and save to a file
-        [Parameter(Mandatory, Position = 0)]
+        # Object to convert to JSON and save it to a file.
+        [Parameter(Mandatory, ValueFromPipeline, Position = 0)]
+        # Check for empty objects here or in the function body?
+        # [ValidateScript({ if (-not [string]::IsNullOrWhiteSpace($_) -and -not [string]::IsNullOrEmpty($_)) { $true } })]
         [Object]
         $Object,
 
-        # Path to save files in
+        # Full path and filename to save the JSON to.
         [Parameter(Position = 1)]
         [string]
-        $Path = $PWD
+        $FilePath
     )
 
-    # Get the passed object name from the first parameter to use as the filename
-    $ObjectName = "$($PSCmdlet.MyInvocation.Statement.Split('$')[1])"
-    $Object | ConvertTo-Json | Out-File -FilePath (Join-Path -Path $Path -ChildPath "${ObjectName}.json") -Force
+    begin {
+        # Validate the file path and extension.
+        if ($FilePath) {
+            # Ensure the $FilePath provided includes a .json extension.
+            if ([System.IO.Path]::GetExtension($FilePath) -ne '.json') {
+                $FilePath = "${FilePath}.json"
+            }
+
+            # Ensure that a working directory is included in filepath.
+            if ([string]::IsNullOrEmpty([System.IO.Path]::GetDirectoryName($FilePath))) {
+                $FilePath = Join-Path -Path (Get-Location -PSProvider FileSystem).Path -ChildPath $FilePath
+            }
+
+            # To Do: Check for a bare directory path and add a filename to it.
+
+            $OutFile = $FilePath
+
+        } else {
+            # If $FilePath is not specified then set $Path to the current location of the FileSystem provider.
+            [string]$Path = (Get-Location -PSProvider FileSystem).Path
+
+            # Set the file name to be the same as the name of the object passed in the first parameter (providing it has a name).
+            $ObjectName = "$($PSCmdlet.MyInvocation.Statement.Split('$')[1])"
+            if ([string]::IsNullOrEmpty($ObjectName)) {
+                # Just name the file "Object.json" if no filename or object name is present.
+                $OutFile = Join-Path -Path $Path -ChildPath 'Object.json'
+            } else {
+                $OutFile = Join-Path -Path $Path -ChildPath "${ObjectName}.json"
+            }
+        }
+    } # end begin block
+
+    process {
+        $Object | ConvertTo-Json | Out-File -FilePath $OutFile -Force
+    } # end process block
+
+    end {
+        Remove-Variable Object, FilePath, Path, OutFile -ErrorAction SilentlyContinue
+    } # end end block
 }


### PR DESCRIPTION
# Pull Request

## Issue

Per [discussion 14](https://github.com/SamErde/PSPreworkout/discussions/14), the original version of this script fails if the current location is using a PSProvider other than FileSystem (eg registry).

## Description

Add ability to accept the source object from the pipeline.

Refactor the FilePath handling to: 
- Ensure it has a .json extension
- Ensure the file saves to the file system if the current PSProvider path is not FileSystem (eg: Registry).

Add cleanup at end.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.