### PR TITLE
Fixup so $IsWindows code doesn't also run on Linux

### DIFF
--- a/Scripts/Update-AllTheThings.ps1
+++ b/Scripts/Update-AllTheThings.ps1
@@ -232,7 +232,7 @@ function Update-AllTheThings {
 
         #region UpdateWinget
         # >>> Create a section to check OS and client/server OS at the top of the script <<< #
-        if ($IsWindows -or ($PSVersionTable.PSVersion -ge [version]'5.1')) {
+        if ($IsWindows -or ($PSVersionTable.PSVersion -le [version]'5.1')) {
 
             if ((Get-CimInstance -ClassName CIM_OperatingSystem).Caption -match 'Server') {
                 # If on Windows Server, prompt to continue before automatically updating packages.


### PR DESCRIPTION
# Pull Request

## Issue
#26


## Description

chagne `-ge` to -le` in test to keep Windows only task `UpdateWinget` from running on Linux systems

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
