### PR TITLE
Remove the .JSON extension requirement on  FilePath.

### DIFF
--- a/docs/Out-JsonFile.md
+++ b/docs/Out-JsonFile.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Out-JsonFile
 
 ## SYNOPSIS
-Convert an object to JSON and write to a file.
+Convert an object to JSON and write it to a file.
 
 ## SYNTAX
 
@@ -48,8 +48,7 @@ Writes $TestObject as JSON to TestObject.json in the current working directory o
 ## PARAMETERS
 
 ### -Object
-Object to convert to JSON and save it to a file.
-Check for empty objects here or in the function body?
+The object to convert to JSON.
 \[ValidateScript({ if (-not \[string\]::IsNullOrWhiteSpace($_) -and -not \[string\]::IsNullOrEmpty($_)) { $true } })\]
 
 ```yaml
@@ -66,6 +65,7 @@ Accept wildcard characters: False
 
 ### -FilePath
 Full path and filename to save the JSON to.
+\[ValidatePattern('\.json$')\] # Do not require a JSON extension.
 
 ```yaml
 Type: String
@@ -89,7 +89,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## NOTES
 Author: Sam Erde
-Version: 0.2.0
-Modified: 2024/10/15
+Version: 0.2.1
+Modified: 2024/10/29
 
 ## RELATED LINKS

--- a/docs/PSPreworkout.md
+++ b/docs/PSPreworkout.md
@@ -51,7 +51,7 @@ Create a new secure credential.
 Create a new advanced function from a template.
 
 ### [Out-JsonFile](Out-JsonFile.md)
-Convert an object to JSON and write to a file.
+Convert an object to JSON and write it to a file.
 
 ### [Set-ConsoleFont](Set-ConsoleFont.md)
 Set the font for your consoles.

--- a/src/Artifacts/PSPreworkout.psm1
+++ b/src/Artifacts/PSPreworkout.psm1
@@ -856,16 +856,16 @@ function Out-JsonFile {
 #>
     [CmdletBinding(HelpUri = 'https://day3bits.com/PSPreworkout/Out-JsonFile')]
     param (
-        # Object to convert to JSON and save it to a file.
+        # The object to convert to JSON.
         [Parameter(Mandatory, ValueFromPipeline, Position = 0)]
-        # Check for empty objects here or in the function body?
         # [ValidateScript({ if (-not [string]::IsNullOrWhiteSpace($_) -and -not [string]::IsNullOrEmpty($_)) { $true } })]
         [Object]
         $Object,
 
         # Full path and filename to save the JSON to.
         [Parameter(Position = 1)]
-        [ValidatePattern('\.json$')]
+        [ValidateNotNullOrEmpty()]
+        # [ValidatePattern('\.json$')] # Do not require a JSON extension.
         [ValidateScript({
                 if ((Split-Path -Path $_).Length -gt 0) {
                     if (Test-Path -Path (Split-Path -Path $_) -PathType Container) {

--- a/src/Artifacts/en-US/PSPreworkout-help.xml
+++ b/src/Artifacts/en-US/PSPreworkout-help.xml
@@ -1379,7 +1379,7 @@ Retrieves the value of the PATH environment variable from the machine target.</d
       <command:verb>Out</command:verb>
       <command:noun>JsonFile</command:noun>
       <maml:description>
-        <maml:para>Convert an object to JSON and write to a file.</maml:para>
+        <maml:para>Convert an object to JSON and write it to a file.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
@@ -1391,7 +1391,7 @@ Retrieves the value of the PATH environment variable from the machine target.</d
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="1" aliases="none">
           <maml:name>Object</maml:name>
           <maml:Description>
-            <maml:para>Object to convert to JSON and save it to a file. Check for empty objects here or in the function body? [ValidateScript({ if (-not [string]::IsNullOrWhiteSpace($ ) -and -not [string]::IsNullOrEmpty($ )) { $true } })]</maml:para>
+            <maml:para>The object to convert to JSON. [ValidateScript({ if (-not [string]::IsNullOrWhiteSpace($ ) -and -not [string]::IsNullOrEmpty($ )) { $true } })]</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
           <dev:type>
@@ -1403,7 +1403,7 @@ Retrieves the value of the PATH environment variable from the machine target.</d
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
           <maml:name>FilePath</maml:name>
           <maml:Description>
-            <maml:para>Full path and filename to save the JSON to.</maml:para>
+            <maml:para>Full path and filename to save the JSON to. [ValidatePattern('\.json$')] # Do not require a JSON extension.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1418,7 +1418,7 @@ Retrieves the value of the PATH environment variable from the machine target.</d
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="1" aliases="none">
         <maml:name>Object</maml:name>
         <maml:Description>
-          <maml:para>Object to convert to JSON and save it to a file. Check for empty objects here or in the function body? [ValidateScript({ if (-not [string]::IsNullOrWhiteSpace($ ) -and -not [string]::IsNullOrEmpty($ )) { $true } })]</maml:para>
+          <maml:para>The object to convert to JSON. [ValidateScript({ if (-not [string]::IsNullOrWhiteSpace($ ) -and -not [string]::IsNullOrEmpty($ )) { $true } })]</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
         <dev:type>
@@ -1430,7 +1430,7 @@ Retrieves the value of the PATH environment variable from the machine target.</d
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
         <maml:name>FilePath</maml:name>
         <maml:Description>
-          <maml:para>Full path and filename to save the JSON to.</maml:para>
+          <maml:para>Full path and filename to save the JSON to. [ValidatePattern('\.json$')] # Do not require a JSON extension.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1444,7 +1444,7 @@ Retrieves the value of the PATH environment variable from the machine target.</d
     <command:returnValues />
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Author: Sam Erde Version: 0.2.0 Modified: 2024/10/15</maml:para>
+        <maml:para>Author: Sam Erde Version: 0.2.1 Modified: 2024/10/29</maml:para>
       </maml:alert>
     </maml:alertSet>
     <command:examples>

--- a/src/PSPreworkout/Public/Out-JsonFile.ps1
+++ b/src/PSPreworkout/Public/Out-JsonFile.ps1
@@ -1,7 +1,7 @@
 function Out-JsonFile {
     <#
     .SYNOPSIS
-        Convert an object to JSON and write to a file.
+        Convert an object to JSON and write it to a file.
 
     .DESCRIPTION
         This function converts an object to JSON and writes the output to the specified file. By default, it saves the
@@ -24,21 +24,21 @@ function Out-JsonFile {
 
     .NOTES
         Author: Sam Erde
-        Version: 0.2.0
-        Modified: 2024/10/15
+        Version: 0.2.1
+        Modified: 2024/10/29
     #>
     [CmdletBinding(HelpUri = 'https://day3bits.com/PSPreworkout/Out-JsonFile')]
     param (
-        # Object to convert to JSON and save it to a file.
+        # The object to convert to JSON.
         [Parameter(Mandatory, ValueFromPipeline, Position = 0)]
-        # Check for empty objects here or in the function body?
         # [ValidateScript({ if (-not [string]::IsNullOrWhiteSpace($_) -and -not [string]::IsNullOrEmpty($_)) { $true } })]
         [Object]
         $Object,
 
         # Full path and filename to save the JSON to.
         [Parameter(Position = 1)]
-        [ValidatePattern('\.json$')]
+        [ValidateNotNullOrEmpty()]
+        # [ValidatePattern('\.json$')] # Do not require a JSON extension.
         [ValidateScript({
                 if ((Split-Path -Path $_).Length -gt 0) {
                     if (Test-Path -Path (Split-Path -Path $_) -PathType Container) {


### PR DESCRIPTION
# Pull Request

## Issue

The .json file extension should not be required. Many JSON use cases rely on files with other extensions or none at all.

## Description

Remove the parameter pattern validation that requires the **FilePath** argument to end with a ".json" string.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.