### PR TITLE
Workflow

### DIFF
--- a/.github/workflows/Publish Release.yml
+++ b/.github/workflows/Publish Release.yml
@@ -3,10 +3,8 @@ name: 🏷️ Publish from Changelog Tag
 # matches this tag and publish a new GitHub release with it, then publish the module to the PowerShell Gallery.
 on:
   push:
-    tags: ['*']
-    branches:
-      - main
-      - prerelease
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/devtest/Build Module.yml
+++ b/.github/workflows/devtest/Build Module.yml
@@ -7,15 +7,16 @@
 # https://github.com/actions/upload-artifact#where-does-the-upload-go
 name: 📦 Build PSPreworkout Module
 on:
-  pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'src/Drafts/**'
-  push:
-    paths:
-      - 'src/**'
-      - '.github/workflows/Build Module.yml'
+  workflow_dispatch:
+  #pull_request:
+  #  paths-ignore:
+  #    - '**.md'
+  #    - 'docs/**'
+  #    - 'src/Drafts/**'
+  #push:
+  #  paths:
+  #    - 'src/**'
+  #    - '.github/workflows/Build Module.yml'
     #paths-ignore:
     #  - '**.md'
     #  - 'docs/**'


### PR DESCRIPTION
This pull request includes changes to two GitHub Actions workflows to refine the conditions under which they are triggered. The most important changes are:

### Workflow Trigger Refinements:

* [`.github/workflows/Publish Release.yml`](diffhunk://#diff-2a8dacb1d81d47252c2ea086745dd258d4187745d6abe35e7a583e3df0acc7a0L6-R7): Updated the `push` event to trigger only on tags that follow the `v*.*.*` pattern, instead of any tag or branch.

* [`.github/workflows/devtest/Build Module.yml`](diffhunk://#diff-b16388332426bb826a08cf4740e5c94fb9ab7fda07aa200e47c9aceca6e48716L10-R19): Changed the workflow to trigger only on manual dispatch (`workflow_dispatch`) and commented out the previous triggers for `pull_request` and `push` events, along with their path filters.
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
