### PR TITLE
Fix workflow paths/pathsignore

### DIFF
--- a/.github/workflows/Build Module.yml
+++ b/.github/workflows/Build Module.yml
@@ -19,10 +19,10 @@ on:
   push:
     paths:
       - 'src/PSPreworkout/**'
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'src/Drafts/**'
+    #paths-ignore: # Cannot use both paths and paths-ignore (don't need both because paths is more specific).
+    #  - '**.md'
+    #  - 'docs/**'
+    #  - 'src/Drafts/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/PowerShell.yml
+++ b/.github/workflows/PowerShell.yml
@@ -5,11 +5,7 @@
 name: 👮‍♂️ PSScriptAnalyzer
 
 on:
-  push:
   pull_request:
-    branches:
-      - main
-      - prerelease
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration for the build module. The change removes the `paths-ignore` section to avoid conflicts with the `paths` section, as both cannot be used simultaneously.

* [`.github/workflows/Build Module.yml`](diffhunk://#diff-1be840213409d0bf544ed815b3d03e1fd157222d3753ae5a02def6983a4c3df8L22-R25): Removed the `paths-ignore` section to prevent conflicts with the `paths` section, ensuring that only the specified paths trigger the workflow.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
