### PR TITLE
Dev general

### DIFF
--- a/docs/Get-EnvironmentVariable.md
+++ b/docs/Get-EnvironmentVariable.md
@@ -128,7 +128,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 ## OUTPUTS
 
-### PSObject
+### System.Collections.Generic.List[PSObject]
 ## NOTES
 Author: Sam Erde
 Version: 0.1.0

--- a/src/Artifacts/PSPreworkout.psm1
+++ b/src/Artifacts/PSPreworkout.psm1
@@ -111,7 +111,7 @@ function Get-EnvironmentVariable {
 #>
     [Alias('gev')]
     [CmdletBinding(HelpUri = 'https://day3bits.com/PSPreworkout/Get-EnvironmentVariable')]
-    [OutputType('PSObject')]
+    [OutputType('System.Collections.Generic.List[PSObject]')]
     param (
         # The name of the environment variable to retrieve. If not specified, all environment variables are returned.
         [Parameter(Position = 0)]
@@ -932,7 +932,7 @@ function New-Credential {
 #>
     [CmdletBinding(HelpUri = 'https://day3bits.com/PSPreworkout/New-Credential')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'OK')]
-    [OutputType([System.Management.Automation.PSCredential])]
+    [OutputType('System.Management.Automation.PSCredential')]
     param ()
 
     Write-Output 'Create a Credential'

--- a/src/Artifacts/en-US/PSPreworkout-help.xml
+++ b/src/Artifacts/en-US/PSPreworkout-help.xml
@@ -196,7 +196,7 @@
     <command:returnValues>
       <command:returnValue>
         <dev:type>
-          <maml:name>PSObject</maml:name>
+          <maml:name>System.Collections.Generic.List[PSObject]</maml:name>
         </dev:type>
         <maml:description>
           <maml:para></maml:para>

--- a/src/PSPreworkout/Public/Get-EnvironmentVariable.ps1
+++ b/src/PSPreworkout/Public/Get-EnvironmentVariable.ps1
@@ -67,7 +67,7 @@ function Get-EnvironmentVariable {
     #>
     [Alias('gev')]
     [CmdletBinding(HelpUri = 'https://day3bits.com/PSPreworkout/Get-EnvironmentVariable')]
-    [OutputType('PSObject')]
+    [OutputType('System.Collections.Generic.List[PSObject]')]
     param (
         # The name of the environment variable to retrieve. If not specified, all environment variables are returned.
         [Parameter(Position = 0)]

--- a/src/PSPreworkout/Public/New-Credential.ps1
+++ b/src/PSPreworkout/Public/New-Credential.ps1
@@ -11,7 +11,7 @@ function New-Credential {
     #>
     [CmdletBinding(HelpUri = 'https://day3bits.com/PSPreworkout/New-Credential')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'OK')]
-    [OutputType([System.Management.Automation.PSCredential])]
+    [OutputType('System.Management.Automation.PSCredential')]
     param ()
 
     Write-Output 'Create a Credential'


### PR DESCRIPTION
This pull request includes changes to the `PSPreworkout` module to update the `OutputType` attributes for several functions and their corresponding documentation. The most important changes are as follows:

### OutputType Updates

* Updated the `OutputType` attribute of the `Get-EnvironmentVariable` function to `System.Collections.Generic.List[PSObject]` in `src/Artifacts/PSPreworkout.psm1` and `src/PSPreworkout/Public/Get-EnvironmentVariable.ps1`. [[1]](diffhunk://#diff-d836dd636990f2e97a9cc698e87b65b18eda3c365c681a5eae523237fc9771f8L114-R114) [[2]](diffhunk://#diff-535db98f257aa04156ae6ae17e72f3f2a656d1540c01f7e6b721311dab4a4e9cL70-R70)
* Updated the `OutputType` attribute of the `New-Credential` function to `System.Management.Automation.PSCredential` in `src/Artifacts/PSPreworkout.psm1` and `src/PSPreworkout/Public/New-Credential.ps1`. [[1]](diffhunk://#diff-d836dd636990f2e97a9cc698e87b65b18eda3c365c681a5eae523237fc9771f8L935-R935) [[2]](diffhunk://#diff-1f9ff715d67d94eef799b8000500293081447aff8b92f92241e7e5eadbcda913L14-R14)

### Documentation Updates

* Updated the return type in the `docs/Get-EnvironmentVariable.md` file to reflect the new `OutputType` for the `Get-EnvironmentVariable` function.
* Updated the return type in the `src/Artifacts/en-US/PSPreworkout-help.xml` file to reflect the new `OutputType` for the `Get-EnvironmentVariable` function.
