### PR TITLE
ci: update MkDocs workflow by removing harden-runner step and specifying Python version 3.12

### DIFF
--- a/.github/workflows/Deploy MkDocs.yml
+++ b/.github/workflows/Deploy MkDocs.yml
@@ -27,18 +27,13 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
-        with:
-          egress-policy: audit
-
       - name: ✅ Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 🐍 Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.x" # specify the Python version
+          python-version: "3.12" # specify the Python version
 
       - name: ➕ Install Dependencies
         run: |


### PR DESCRIPTION
# Pull Request

Pin Python to 3.12 in the MkDocs workflow to fix breaking changes.