### PR TITLE
🐛 fix(module): prepare branch for PR readiness

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,7 +20,8 @@ When you add a new public function to the module, the build process and GitHub A
 
 - The function name in `FunctionsToExport`
 - Any aliases defined with `[Alias()]` attributes in `AliasesToExport`
-- Aliases are also added to `FunctionsToExport` per this module's convention
+
+Aliases should not be added to `FunctionsToExport`.
 
 ### How It Works
 

--- a/.github/cicd-scripts/Update-MkDocsNavigation.ps1
+++ b/.github/cicd-scripts/Update-MkDocsNavigation.ps1
@@ -3,7 +3,7 @@
     Updates the navigation section in mkdocs.yml based on functions exported from the PowerShell module manifest.
 
 .DESCRIPTION
-    This script reads the FunctionsToExport from the PowerShell module manifest, categorizes them
+    This script reads FunctionsToExport from the PowerShell module manifest, categorizes them
     into three groups (Customize, Develop, Daily Functions), and updates the nav section in mkdocs.yml.
     It preserves all other content in mkdocs.yml while only updating the navigation structure.
 
@@ -14,10 +14,10 @@
     Path to the mkdocs.yml configuration file.
 
 .EXAMPLE
-    .\Update-MkDocsNavigation.ps1
+    .\.github\cicd-scripts\Update-MkDocsNavigation.ps1
 
 .EXAMPLE
-    .\Update-MkDocsNavigation.ps1 -ManifestPath "./src/PSPreworkout/PSPreworkout.psd1" -MkDocsPath "./mkdocs.yml"
+    .\.github\cicd-scripts\Update-MkDocsNavigation.ps1 -ManifestPath "./src/PSPreworkout/PSPreworkout.psd1" -MkDocsPath "./mkdocs.yml"
 #>
 
 [CmdletBinding()]
@@ -87,8 +87,9 @@ function Get-CategorizedFunctions {
         Reads functions from manifest and categorizes them.
 
     .DESCRIPTION
-        Imports the PowerShell module manifest, filters out aliases, and categorizes
-        the remaining functions into their respective groups.
+        Imports the PowerShell module manifest and categorizes exported functions into
+        their respective groups. Aliases are expected to be exported only through
+        AliasesToExport and are not included in FunctionsToExport.
     #>
     [CmdletBinding()]
     param (
@@ -103,17 +104,7 @@ function Get-CategorizedFunctions {
     Write-Verbose "Reading manifest from: $ManifestPath"
     $manifest = Import-PowerShellDataFile -Path $ManifestPath
 
-    # Filter out aliases - these are shorter versions of function names
-    $aliases = @(
-        'Edit-HistoryFile',
-        'Get-Assembly',
-        'Get-PSPortable',
-        'Init-PSEnvConfig',
-        'New-Script',
-        'Show-LoadedAssemblies'
-    )
-
-    $functions = $manifest.FunctionsToExport | Where-Object { $_ -notin $aliases } | Sort-Object
+    $functions = $manifest.FunctionsToExport | Sort-Object
 
     $categorized = @{
         Customize       = @()

--- a/.github/cicd-scripts/Update-MkDocsNavigation.ps1
+++ b/.github/cicd-scripts/Update-MkDocsNavigation.ps1
@@ -243,38 +243,40 @@ function Update-MkDocsYaml {
 
 #endregion Helper Functions
 
-#region Main Script
+if ($MyInvocation.InvocationName -ne '.') {
+    #region Main Script
 
-try {
-    Write-Host "🔍 Analyzing PowerShell module manifest..." -ForegroundColor Cyan
+    try {
+        Write-Host "🔍 Analyzing PowerShell module manifest..." -ForegroundColor Cyan
 
-    # Get categorized functions from manifest
-    $categorizedFunctions = Get-CategorizedFunctions -ManifestPath $ManifestPath
+        # Get categorized functions from manifest
+        $categorizedFunctions = Get-CategorizedFunctions -ManifestPath $ManifestPath
 
-    Write-Host "📊 Function counts:" -ForegroundColor Cyan
-    Write-Host "   Customize: $($categorizedFunctions['Customize'].Count)" -ForegroundColor Green
-    Write-Host "   Develop: $($categorizedFunctions['Develop'].Count)" -ForegroundColor Green
-    Write-Host "   Daily Functions: $($categorizedFunctions['Daily Functions'].Count)" -ForegroundColor Green
+        Write-Host "📊 Function counts:" -ForegroundColor Cyan
+        Write-Host "   Customize: $($categorizedFunctions['Customize'].Count)" -ForegroundColor Green
+        Write-Host "   Develop: $($categorizedFunctions['Develop'].Count)" -ForegroundColor Green
+        Write-Host "   Daily Functions: $($categorizedFunctions['Daily Functions'].Count)" -ForegroundColor Green
 
-    # Generate new navigation YAML
-    Write-Host "`n📝 Generating navigation structure..." -ForegroundColor Cyan
-    $newNavLines = New-NavigationYaml -CategorizedFunctions $categorizedFunctions
+        # Generate new navigation YAML
+        Write-Host "`n📝 Generating navigation structure..." -ForegroundColor Cyan
+        $newNavLines = New-NavigationYaml -CategorizedFunctions $categorizedFunctions
 
-    # Update mkdocs.yml
-    Write-Host "📄 Updating mkdocs.yml..." -ForegroundColor Cyan
-    $updated = Update-MkDocsYaml -MkDocsPath $MkDocsPath -NewNavLines $newNavLines
+        # Update mkdocs.yml
+        Write-Host "📄 Updating mkdocs.yml..." -ForegroundColor Cyan
+        $updated = Update-MkDocsYaml -MkDocsPath $MkDocsPath -NewNavLines $newNavLines
 
-    if ($updated) {
-        Write-Host "✅ Successfully updated mkdocs.yml navigation!" -ForegroundColor Green
-        exit 0
-    } else {
-        Write-Host "❌ Failed to update mkdocs.yml" -ForegroundColor Red
+        if ($updated) {
+            Write-Host "✅ Successfully updated mkdocs.yml navigation!" -ForegroundColor Green
+            exit 0
+        } else {
+            Write-Host "❌ Failed to update mkdocs.yml" -ForegroundColor Red
+            exit 1
+        }
+    } catch {
+        Write-Host "❌ Error: $_" -ForegroundColor Red
+        Write-Host $_.ScriptStackTrace -ForegroundColor Red
         exit 1
     }
-} catch {
-    Write-Host "❌ Error: $_" -ForegroundColor Red
-    Write-Host $_.ScriptStackTrace -ForegroundColor Red
-    exit 1
-}
 
-#endregion Main Script
+    #endregion Main Script
+}

--- a/.github/cicd-scripts/Update-MkDocsNavigation.ps1
+++ b/.github/cicd-scripts/Update-MkDocsNavigation.ps1
@@ -81,7 +81,7 @@ function Get-FunctionCategory {
     }
 }
 
-function Get-CategorizedFunctions {
+function Get-CategorizedFunction {
     <#
     .SYNOPSIS
         Reads functions from manifest and categorizes them.
@@ -121,13 +121,13 @@ function Get-CategorizedFunctions {
     return $categorized
 }
 
-function New-NavigationYaml {
+function ConvertTo-NavigationYaml {
     <#
     .SYNOPSIS
         Generates the nav section YAML content.
 
     .DESCRIPTION
-        Creates the YAML structure for the nav section based on categorized functions.
+        Converts categorized functions into YAML structure for the nav section.
     #>
     [CmdletBinding()]
     param (
@@ -175,7 +175,7 @@ function Update-MkDocsYaml {
         Reads the existing mkdocs.yml, replaces the nav section with the updated version,
         and writes it back to the file.
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [Parameter(Mandatory)]
         [string]$MkDocsPath,
@@ -235,10 +235,13 @@ function Update-MkDocsYaml {
         $newContent += $lines[($navEndIndex + 1)..($lines.Count - 1)]
     }
 
-    Write-Verbose "Writing updated mkdocs.yml with $($newContent.Count) lines"
-    $newContent | Set-Content -Path $MkDocsPath
+    if ($PSCmdlet.ShouldProcess($MkDocsPath, 'Update MkDocs navigation')) {
+        Write-Verbose "Writing updated mkdocs.yml with $($newContent.Count) lines"
+        $newContent | Set-Content -Path $MkDocsPath
+        return $true
+    }
 
-    return $true
+    return $false
 }
 
 #endregion Helper Functions
@@ -247,34 +250,34 @@ if ($MyInvocation.InvocationName -ne '.') {
     #region Main Script
 
     try {
-        Write-Host "🔍 Analyzing PowerShell module manifest..." -ForegroundColor Cyan
+        Write-Information "Analyzing PowerShell module manifest..." -InformationAction Continue
 
         # Get categorized functions from manifest
-        $categorizedFunctions = Get-CategorizedFunctions -ManifestPath $ManifestPath
+        $categorizedFunctions = Get-CategorizedFunction -ManifestPath $ManifestPath
 
-        Write-Host "📊 Function counts:" -ForegroundColor Cyan
-        Write-Host "   Customize: $($categorizedFunctions['Customize'].Count)" -ForegroundColor Green
-        Write-Host "   Develop: $($categorizedFunctions['Develop'].Count)" -ForegroundColor Green
-        Write-Host "   Daily Functions: $($categorizedFunctions['Daily Functions'].Count)" -ForegroundColor Green
+        Write-Information "Function counts:" -InformationAction Continue
+        Write-Information "   Customize: $($categorizedFunctions['Customize'].Count)" -InformationAction Continue
+        Write-Information "   Develop: $($categorizedFunctions['Develop'].Count)" -InformationAction Continue
+        Write-Information "   Daily Functions: $($categorizedFunctions['Daily Functions'].Count)" -InformationAction Continue
 
         # Generate new navigation YAML
-        Write-Host "`n📝 Generating navigation structure..." -ForegroundColor Cyan
-        $newNavLines = New-NavigationYaml -CategorizedFunctions $categorizedFunctions
+        Write-Information "`nGenerating navigation structure..." -InformationAction Continue
+        $newNavLines = ConvertTo-NavigationYaml -CategorizedFunctions $categorizedFunctions
 
         # Update mkdocs.yml
-        Write-Host "📄 Updating mkdocs.yml..." -ForegroundColor Cyan
+        Write-Information "Updating mkdocs.yml..." -InformationAction Continue
         $updated = Update-MkDocsYaml -MkDocsPath $MkDocsPath -NewNavLines $newNavLines
 
         if ($updated) {
-            Write-Host "✅ Successfully updated mkdocs.yml navigation!" -ForegroundColor Green
+            Write-Information "Successfully updated mkdocs.yml navigation." -InformationAction Continue
             exit 0
         } else {
-            Write-Host "❌ Failed to update mkdocs.yml" -ForegroundColor Red
+            Write-Error "Failed to update mkdocs.yml."
             exit 1
         }
     } catch {
-        Write-Host "❌ Error: $_" -ForegroundColor Red
-        Write-Host $_.ScriptStackTrace -ForegroundColor Red
+        Write-Error "Error: $_"
+        Write-Error $_.ScriptStackTrace
         exit 1
     }
 

--- a/.github/workflows/Update MkDocs Navigation.yml
+++ b/.github/workflows/Update MkDocs Navigation.yml
@@ -42,7 +42,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           Write-Host "Running Update-MkDocsNavigation script..."
           try {
-            ./Scripts/Update-MkDocsNavigation.ps1 -Verbose
+            ./.github/cicd-scripts/Update-MkDocsNavigation.ps1 -Verbose
             Write-Host "✅ Script completed successfully"
           } catch {
             Write-Error "❌ Failed to update navigation: $_"

--- a/.github/workflows/Validate Module Manifest.yml
+++ b/.github/workflows/Validate Module Manifest.yml
@@ -76,36 +76,37 @@ jobs:
               return $functions
           }
 
-          # Function to extract aliases
+          # Function to extract function-level command aliases
           function Get-PublicAliases {
               param($Path)
 
               $aliases = Get-ChildItem -Path "$Path/Public/*.ps1" -ErrorAction SilentlyContinue |
                   ForEach-Object {
                       try {
-                          $lines = Get-Content -Path $_.FullName -ErrorAction Stop
-                          $foundAliases = @()
-
-                          foreach ($line in $lines) {
-                              # Skip comments and variable assignments
-                              if ($line -match '^\s*#' -or $line -match '=.*\[Alias') {
-                                  continue
-                              }
-
-                              if ($line -match '^\s*\[Alias\((.*?)\)\]') {
-                                  $aliasString = $matches[1]
-                                  $lineAliases = $aliasString -split ',' | ForEach-Object {
-                                      $cleaned = $_.Trim().Trim("'").Trim('"').Trim()
-                                      if ($cleaned -and $cleaned -notmatch '^\$' -and $cleaned -notmatch '__') {
-                                          $cleaned
-                                      }
-                                  } | Where-Object { $_ }
-
-                                  $foundAliases += $lineAliases
-                              }
+                          $tokens = $null
+                          $parseErrors = $null
+                          $ast = [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$parseErrors)
+                          if ($parseErrors) {
+                              Write-Host "::warning::Failed to parse aliases from $($_.Name): $($parseErrors[0].Message)"
+                              return
                           }
 
-                          $foundAliases
+                          $functionAsts = $ast.FindAll({
+                                  param($Node)
+                                  $Node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+                              }, $true)
+
+                          foreach ($functionAst in $functionAsts) {
+                              foreach ($attribute in $functionAst.Body.ParamBlock.Attributes) {
+                                  if ($attribute.TypeName.FullName -eq 'Alias') {
+                                      foreach ($argument in $attribute.PositionalArguments) {
+                                          if ($argument -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+                                              $argument.Value
+                                          }
+                                      }
+                                  }
+                              }
+                          }
                       } catch {
                           Write-Host "::warning::Failed to parse aliases from $($_.Name): $_"
                       }
@@ -138,9 +139,9 @@ jobs:
           # Compare - check if functions are in FunctionsToExport
           $missingFunctions = $publicFunctions | Where-Object { $_ -notin $manifestData.FunctionsToExport }
 
-          # Check if aliases are in both FunctionsToExport and AliasesToExport (per module convention)
-          $missingFromFunctionsExport = $aliases | Where-Object { $_ -notin $manifestData.FunctionsToExport }
+          # Aliases are exported only through AliasesToExport.
           $missingFromAliasesExport = $aliases | Where-Object { $_ -notin $manifestData.AliasesToExport }
+          $aliasesInFunctionsExport = $aliases | Where-Object { $_ -in $manifestData.FunctionsToExport }
 
           $needsUpdate = $false
 
@@ -150,15 +151,15 @@ jobs:
               $needsUpdate = $true
           }
 
-          if ($missingFromFunctionsExport) {
-              Write-Host "Missing aliases in FunctionsToExport:" -ForegroundColor Red
-              $missingFromFunctionsExport | ForEach-Object { Write-Host "  - $_" }
-              $needsUpdate = $true
-          }
-
           if ($missingFromAliasesExport) {
               Write-Host "Missing aliases in AliasesToExport:" -ForegroundColor Red
               $missingFromAliasesExport | ForEach-Object { Write-Host "  - $_" }
+              $needsUpdate = $true
+          }
+
+          if ($aliasesInFunctionsExport) {
+              Write-Host "Aliases should not be listed in FunctionsToExport:" -ForegroundColor Red
+              $aliasesInFunctionsExport | ForEach-Object { Write-Host "  - $_" }
               $needsUpdate = $true
           }
 
@@ -202,36 +203,37 @@ jobs:
               return $functions
           }
 
-          # Function to extract aliases
+          # Function to extract function-level command aliases
           function Get-PublicAliases {
               param($Path)
 
               $aliases = Get-ChildItem -Path "$Path/Public/*.ps1" -ErrorAction SilentlyContinue |
                   ForEach-Object {
                       try {
-                          $lines = Get-Content -Path $_.FullName -ErrorAction Stop
-                          $foundAliases = @()
-
-                          foreach ($line in $lines) {
-                              # Skip comments and variable assignments
-                              if ($line -match '^\s*#' -or $line -match '=.*\[Alias') {
-                                  continue
-                              }
-
-                              if ($line -match '^\s*\[Alias\((.*?)\)\]') {
-                                  $aliasString = $matches[1]
-                                  $lineAliases = $aliasString -split ',' | ForEach-Object {
-                                      $cleaned = $_.Trim().Trim("'").Trim('"').Trim()
-                                      if ($cleaned -and $cleaned -notmatch '^\$' -and $cleaned -notmatch '__') {
-                                          $cleaned
-                                      }
-                                  } | Where-Object { $_ }
-
-                                  $foundAliases += $lineAliases
-                              }
+                          $tokens = $null
+                          $parseErrors = $null
+                          $ast = [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$parseErrors)
+                          if ($parseErrors) {
+                              Write-Host "::warning::Failed to parse aliases from $($_.Name): $($parseErrors[0].Message)"
+                              return
                           }
 
-                          $foundAliases
+                          $functionAsts = $ast.FindAll({
+                                  param($Node)
+                                  $Node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+                              }, $true)
+
+                          foreach ($functionAst in $functionAsts) {
+                              foreach ($attribute in $functionAst.Body.ParamBlock.Attributes) {
+                                  if ($attribute.TypeName.FullName -eq 'Alias') {
+                                      foreach ($argument in $attribute.PositionalArguments) {
+                                          if ($argument -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+                                              $argument.Value
+                                          }
+                                      }
+                                  }
+                              }
+                          }
                       } catch {
                           Write-Host "::warning::Failed to parse aliases from $($_.Name): $_"
                       }
@@ -254,14 +256,10 @@ jobs:
 
           $originalManifestContent = $manifestContent
 
-          # Update FunctionsToExport (functions + aliases per module convention)
-          $allExports = @($publicFunctions)
-          if ($aliases) {
-              $allExports += $aliases
-          }
-          $allExportsArray = ($allExports | Sort-Object -Unique | ForEach-Object { "'$_'" }) -join ",`n        "
+          # Update FunctionsToExport with command functions only. Aliases belong in AliasesToExport.
+          $functionsToExportArray = ($publicFunctions | Sort-Object -Unique | ForEach-Object { "'$_'" }) -join ",`n        "
           $functionsToExportPattern = '(?ms)(FunctionsToExport\s*=\s*@\().*?(\s*\))'
-          $newFunctionsToExport = "`$1`n        $allExportsArray`n    )"
+          $newFunctionsToExport = "`$1`n        $functionsToExportArray`n    )"
           $manifestContent = $manifestContent -replace $functionsToExportPattern, $newFunctionsToExport
 
           # Update AliasesToExport

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -1,47 +1,9 @@
 # Scripts
 
-This directory contains scripts from **PSPreworkout** that may also be published separately to the PowerShell Gallery, as well as automation scripts for repository maintenance.
+This directory contains public scripts from **PSPreworkout** that may also be published separately to the PowerShell Gallery.
 
 ## Update-AllTheThings
 
 - Build: Run `Update-AllTheThings_Build.ps1`
 - Script Metadata: `Update-AllTheThings_ScriptInfo.ps1`
 - Script to Publish: **Update-AllTheThings.ps1**
-
-## Update-MkDocsNavigation.ps1
-
-A PowerShell script that automatically updates the navigation section in `mkdocs.yml` based on the functions exported in the PowerShell module manifest (`PSPreworkout.psd1`).
-
-### Features
-
-- Reads `FunctionsToExport` from the module manifest
-- Filters out aliases to include only actual functions
-- Categorizes functions into three groups:
-  - **Customize**: Functions for configuring PowerShell environment
-  - **Develop**: Functions for PowerShell development tasks
-  - **Daily Functions**: General utility functions for daily operations
-- Updates the `nav:` section in mkdocs.yml while preserving all other content
-- Sorts functions alphabetically within each category
-
-### Usage
-
-```powershell
-# Run from repository root
-.\Scripts\Update-MkDocsNavigation.ps1
-
-# With verbose output
-.\Scripts\Update-MkDocsNavigation.ps1 -Verbose
-
-# Specify custom paths
-.\Scripts\Update-MkDocsNavigation.ps1 -ManifestPath "./src/PSPreworkout/PSPreworkout.psd1" -MkDocsPath "./mkdocs.yml"
-```
-
-### Automation
-
-This script is automatically executed by the **Update MkDocs Navigation** GitHub Actions workflow whenever changes are pushed to the module manifest (`PSPreworkout.psd1`) on the main branch. The workflow:
-
-1. Runs the script to update mkdocs.yml
-2. Checks if any changes were made
-3. Commits and pushes the updated mkdocs.yml back to the repository
-
-This ensures that the documentation navigation always stays in sync with the exported functions.

--- a/docs/MKDOCS-NAVIGATION-AUTOMATION.md
+++ b/docs/MKDOCS-NAVIGATION-AUTOMATION.md
@@ -17,15 +17,15 @@ Previously, the `nav` section in `mkdocs.yml` had to be manually maintained when
 
 An automated system that:
 
-1. Reads the `FunctionsToExport` from the module manifest (`PSPreworkout.psd1`)
-2. Filters out aliases to include only actual functions
+1. Reads `FunctionsToExport` from the module manifest (`PSPreworkout.psd1`)
+2. Relies on aliases being exported only through `AliasesToExport`
 3. Categorizes functions into three logical groups
 4. Updates the `mkdocs.yml` navigation section automatically
 5. Triggers whenever the module manifest is updated on the main branch
 
 ## Components
 
-### 1. PowerShell Script (`Scripts/Update-MkDocsNavigation.ps1`)
+### 1. PowerShell Script (`.github/cicd-scripts/Update-MkDocsNavigation.ps1`)
 
 **Purpose**: Updates the navigation section in mkdocs.yml based on the module manifest.
 
@@ -98,13 +98,13 @@ Run the script directly:
 
 ```powershell
 # From repository root
-.\Scripts\Update-MkDocsNavigation.ps1
+.\.github\cicd-scripts\Update-MkDocsNavigation.ps1
 
 # With verbose output
-.\Scripts\Update-MkDocsNavigation.ps1 -Verbose
+.\.github\cicd-scripts\Update-MkDocsNavigation.ps1 -Verbose
 
 # With custom paths
-.\Scripts\Update-MkDocsNavigation.ps1 -ManifestPath "path/to/manifest.psd1" -MkDocsPath "path/to/mkdocs.yml"
+.\.github\cicd-scripts\Update-MkDocsNavigation.ps1 -ManifestPath "path/to/manifest.psd1" -MkDocsPath "path/to/mkdocs.yml"
 ```
 
 ## Benefits
@@ -128,7 +128,7 @@ Run the script directly:
 
 To change which category a function belongs to:
 
-1. Edit the `Get-FunctionCategory` function in `Scripts/Update-MkDocsNavigation.ps1`
+1. Edit the `Get-FunctionCategory` function in `.github/cicd-scripts/Update-MkDocsNavigation.ps1`
 2. Update the `$developFunctions` or `$customizeFunctions` arrays
 3. Run the script manually or push changes to trigger the workflow
 
@@ -142,10 +142,10 @@ Invoke-Pester -Path ./src/Tests/Unit/Update-MkDocsNavigation.Tests.ps1
 
 ## Files Modified
 
-- ✅ `Scripts/Update-MkDocsNavigation.ps1` - Created
+- ✅ `.github/cicd-scripts/Update-MkDocsNavigation.ps1` - Created
 - ✅ `.github/workflows/Update MkDocs Navigation.yml` - Created
 - ✅ `src/Tests/Unit/Update-MkDocsNavigation.Tests.ps1` - Created
-- ✅ `Scripts/README.md` - Updated with documentation
+- ✅ `docs/MKDOCS-NAVIGATION-AUTOMATION.md` - Updated with documentation
 - ✅ `mkdocs.yml` - Fixed navigation (removed duplicates, corrected typos, added missing functions)
 
 ## Example: Before and After

--- a/src/Draft/Update-MkDocsNavigation.Tests.ps1
+++ b/src/Draft/Update-MkDocsNavigation.Tests.ps1
@@ -1,5 +1,5 @@
 BeforeAll {
-    $ScriptPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, '..', '..', '..', 'Scripts', 'Update-MkDocsNavigation.ps1'))
+    $ScriptPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, '..', '..', '.github', 'cicd-scripts', 'Update-MkDocsNavigation.ps1'))
     $ManifestPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, '..', '..', 'PSPreworkout', 'PSPreworkout.psd1'))
     $MkDocsPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, '..', '..', '..', 'mkdocs.yml'))
 
@@ -122,7 +122,7 @@ Describe 'Update-MkDocsNavigation Script Tests' -Tag Unit {
             $categorized['Daily Functions'].Count | Should -BeGreaterThan 0
         }
 
-        It 'should exclude known aliases from categorization' {
+        It 'should not categorize aliases from AliasesToExport' {
             if ($null -eq $categorized) {
                 Set-ItResult -Skipped -Because "Manifest file not accessible in test environment"
                 return
@@ -209,8 +209,9 @@ Describe 'Update-MkDocsNavigation Script Tests' -Tag Unit {
         'Install-CommandNotFoundUtility',
         'New-ScriptFromTemplate',
         'Get-CommandHistory',
-        'Test-IsElevated',
-        # Aliases (should be filtered out)
+        'Test-IsElevated'
+    )
+    AliasesToExport = @(
         'Edit-HistoryFile',
         'Get-Assembly',
         'New-Script'

--- a/src/PSPreworkout.build.ps1
+++ b/src/PSPreworkout.build.ps1
@@ -151,36 +151,32 @@ Add-BuildTask UpdateManifest -Before TestModuleManifest {
 
     Write-Build Gray "      Found $($publicFunctions.Count) public functions"
 
-    # Get all aliases from public functions - improved detection
+    # Get command aliases declared on public functions. Parameter aliases are not module aliases.
     $aliases = Get-ChildItem -Path "$script:ModuleSourcePath\Public\*.ps1" -ErrorAction SilentlyContinue |
         ForEach-Object {
-            # Read line by line to better understand context and avoid string literals
-            $lines = Get-Content -Path $_.FullName
-            $foundAliases = @()
-
-            foreach ($line in $lines) {
-                # Skip lines that are clearly in strings or variable assignments
-                if ($line -match '^\s*#' -or $line -match '=.*\[Alias') {
-                    continue
-                }
-
-                # Match [Alias(...)] attribute declarations
-                if ($line -match '^\s*\[Alias\((.*?)\)\]') {
-                    $aliasString = $matches[1]
-                    # Split by comma and clean up each alias
-                    $lineAliases = $aliasString -split ',' | ForEach-Object {
-                        $cleaned = $_.Trim().Trim("'").Trim('"').Trim()
-                        # Filter out variables, template placeholders, and empty strings
-                        if ($cleaned -and $cleaned -notmatch '^\$' -and $cleaned -notmatch '__') {
-                            $cleaned
-                        }
-                    } | Where-Object { $_ }
-
-                    $foundAliases += $lineAliases
-                }
+            $tokens = $null
+            $parseErrors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$parseErrors)
+            if ($parseErrors) {
+                throw "Unable to parse $($_.FullName): $($parseErrors[0].Message)"
             }
 
-            $foundAliases
+            $functionAsts = $ast.FindAll({
+                    param($Node)
+                    $Node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+                }, $true)
+
+            foreach ($functionAst in $functionAsts) {
+                foreach ($attribute in $functionAst.Body.ParamBlock.Attributes) {
+                    if ($attribute.TypeName.FullName -eq 'Alias') {
+                        foreach ($argument in $attribute.PositionalArguments) {
+                            if ($argument -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+                                $argument.Value
+                            }
+                        }
+                    }
+                }
+            }
         } | Sort-Object -Unique
 
     Write-Build Gray "      Found $($aliases.Count) unique aliases in public functions"
@@ -190,18 +186,10 @@ Add-BuildTask UpdateManifest -Before TestModuleManifest {
     $manifestContent = Get-Content -Path $manifestPath -Raw
     $originalManifestContent = $manifestContent
 
-    # Update FunctionsToExport
-    $functionsArray = ($publicFunctions | ForEach-Object { "'$_'" }) -join ",`n        "
+    # Update FunctionsToExport with command functions only. Aliases belong in AliasesToExport.
     $functionsToExportPattern = '(?ms)(FunctionsToExport\s*=\s*@\().*?(\s*\))'
-
-    # Build complete export list: functions first, then aliases that should be exported as functions
-    $allExports = @($publicFunctions)
-    if ($aliases) {
-        $allExports += @($aliases -match '\w-\w')
-    }
-    $allExportsArray = ($allExports | Sort-Object -Unique | ForEach-Object { "'$_'" }) -join ",`n        "
-
-    $newFunctionsToExport = "`$1`n        $allExportsArray`n    )"
+    $functionsToExportArray = ($publicFunctions | Sort-Object -Unique | ForEach-Object { "'$_'" }) -join ",`n        "
+    $newFunctionsToExport = "`$1`n        $functionsToExportArray`n    )"
     $manifestContent = $manifestContent -replace $functionsToExportPattern, $newFunctionsToExport
 
     # Update AliasesToExport

--- a/src/PSPreworkout/PSPreworkout.psd1
+++ b/src/PSPreworkout/PSPreworkout.psd1
@@ -28,31 +28,25 @@
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport    = @(
-        'Edit-HistoryFile',
         'Edit-PSReadLineHistoryFile',
         'Edit-WinGetSettingsFile',
-        'Get-Assembly',
         'Get-CommandHistory',
         'Get-EnvironmentVariable',
         'Get-HashtableValueType',
         'Get-LoadedAssembly',
         'Get-ModulesWithUpdate',
         'Get-PowerShellPortable',
-        'Get-PSPortable',
         'Get-TypeAccelerator',
-        'Init-PSEnvConfig',
         'Initialize-PSEnvironmentConfiguration',
         'Install-CommandNotFoundUtility',
         'Install-OhMyPosh',
         'Install-PowerShellISE',
         'Install-WinGet',
-        'New-Script',
         'New-ScriptFromTemplate',
         'Out-JsonFile',
         'Set-ConsoleFont',
         'Set-DefaultTerminal',
         'Set-EnvironmentVariable',
-        'Show-LoadedAssemblies',
         'Show-LoadedAssembly',
         'Show-WithoutEmptyProperty',
         'Test-IsElevated',
@@ -78,7 +72,6 @@
         'New-Script',
         'sev',
         'Show-LoadedAssemblies',
-        'SkipChoco',
         'uatt'
     )
 

--- a/src/Tests/Integration/SampleIntegrationTest.Tests.ps1
+++ b/src/Tests/Integration/SampleIntegrationTest.Tests.ps1
@@ -1,18 +1,20 @@
-BeforeAll {
-    Set-Location -Path $PSScriptRoot
-    $ModuleName = 'PSPreworkout'
-    # $PathToManifest = [System.IO.Path]::Combine('..', '..', 'Artifacts', "$ModuleName.psd1")
-    # If the module is already in memory, remove it.
-    # Get-Module $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
-    # Import-Module $PathToManifest -Force
-}
-
 Describe 'Integration Tests' -Tag Integration {
+    BeforeAll {
+        Set-Location -Path $PSScriptRoot
+        $ModuleName = 'PSPreworkout'
+        # $PathToManifest = [System.IO.Path]::Combine('..', '..', 'Artifacts', "$ModuleName.psd1")
+        # If the module is already in memory, remove it.
+        # Get-Module $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+        # Import-Module $PathToManifest -Force
+    }
+
+    AfterAll {
+        Get-Module -Name $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+    }
+
     Context 'First Integration Tests' {
         It 'should pass the first integration test' {
             # test logic
         } #it
     }
 }
-
-Remove-Module $ModuleName -Force

--- a/src/Tests/Unit/ExportedFunctions.Tests.ps1
+++ b/src/Tests/Unit/ExportedFunctions.Tests.ps1
@@ -5,16 +5,22 @@ BeforeAll {
     Get-Module $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
     Import-Module $PathToManifest -Force
     $manifestContent = Test-ModuleManifest -Path $PathToManifest
-    $moduleExported = Get-Command -Module $ModuleName | Select-Object -ExpandProperty Name
-    $manifestExported = ($manifestContent.ExportedFunctions).Keys
+    $moduleCommands = Get-Command -Module $ModuleName
+    $moduleExportedFunctions = $moduleCommands | Where-Object CommandType -EQ 'Function' | Select-Object -ExpandProperty Name
+    $manifestExportedFunctions = ($manifestContent.ExportedFunctions).Keys
+    $manifestExportedAliases = ($manifestContent.ExportedAliases).Keys
 }
 BeforeDiscovery {
     Set-Location -Path $PSScriptRoot
     $ModuleName = 'PSPreworkout'
     $PathToManifest = [System.IO.Path]::Combine('..', '..', $ModuleName, "$ModuleName.psd1")
+    Get-Module $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $PathToManifest -Force
     $manifestContent = Test-ModuleManifest -Path $PathToManifest
-    $moduleExported = Get-Command -Module $ModuleName | Select-Object -ExpandProperty Name
-    $manifestExported = ($manifestContent.ExportedFunctions).Keys
+    $moduleCommands = Get-Command -Module $ModuleName
+    $moduleExportedFunctions = $moduleCommands | Where-Object CommandType -EQ 'Function' | Select-Object -ExpandProperty Name
+    $manifestExportedFunctions = ($manifestContent.ExportedFunctions).Keys
+    $manifestExportedAliases = ($manifestContent.ExportedAliases).Keys
 }
 Describe $ModuleName {
 
@@ -23,22 +29,33 @@ Describe $ModuleName {
         Context 'Number of commands' -Fixture {
 
             It 'Exports the same number of public functions as what is listed in the Module Manifest' {
-                $manifestExported.Count | Should -BeExactly $moduleExported.Count
+                $manifestExportedFunctions.Count | Should -BeExactly $moduleExportedFunctions.Count
             }
 
         }
 
         Context 'Explicitly exported commands' {
 
-            It 'Includes <_> in the Module Manifest ExportedFunctions' -ForEach $moduleExported {
-                $manifestExported -contains $_ | Should -BeTrue
+            It 'Includes <_> in the Module Manifest ExportedFunctions' -ForEach $moduleExportedFunctions {
+                $manifestExportedFunctions -contains $_ | Should -BeTrue
+            }
+
+            It 'Does not include alias <_> in the Module Manifest ExportedFunctions' -ForEach $manifestExportedAliases {
+                $manifestExportedFunctions -contains $_ | Should -BeFalse
+            }
+
+            It 'Resolves alias <_> to a module command' -ForEach $manifestExportedAliases {
+                $alias = Get-Alias -Name $_ -ErrorAction Stop
+
+                $alias.Source | Should -BeExactly $ModuleName
+                $manifestExportedFunctions -contains $alias.ResolvedCommandName | Should -BeTrue
             }
 
         }
     } #context_ExportedCommands
 
     Context 'Command Help' -Fixture {
-        Context '<_>' -Foreach $moduleExported {
+        Context '<_>' -Foreach $moduleCommands.Name {
 
             BeforeEach {
                 $help = Get-Help -Name $_ -Full

--- a/src/Tests/Unit/Update-MkDocsNavigation.Tests.ps1
+++ b/src/Tests/Unit/Update-MkDocsNavigation.Tests.ps1
@@ -1,28 +1,26 @@
 BeforeAll {
-    $ScriptPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, '..', '..', '.github', 'cicd-scripts', 'Update-MkDocsNavigation.ps1'))
-    $ManifestPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, '..', '..', 'PSPreworkout', 'PSPreworkout.psd1'))
-    $MkDocsPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, '..', '..', '..', 'mkdocs.yml'))
-
+    $NavigationScriptPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, '..', '..', '..', '.github', 'cicd-scripts', 'Update-MkDocsNavigation.ps1'))
+    $ModuleManifestPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, '..', '..', 'PSPreworkout', 'PSPreworkout.psd1'))
     # Source the script to get access to its functions
-    . $ScriptPath
+    . $NavigationScriptPath
 }
 
 Describe 'Update-MkDocsNavigation Script Tests' -Tag Unit {
     Context 'Script File Tests' {
         It 'Update-MkDocsNavigation.ps1 should exist' {
-            $ScriptPath | Should -Exist
+            $NavigationScriptPath | Should -Exist
         }
 
         It 'should have valid PowerShell syntax' {
             $errors = $null
-            $null = [System.Management.Automation.PSParser]::Tokenize((Get-Content -Path $ScriptPath -Raw), [ref]$errors)
+            $null = [System.Management.Automation.PSParser]::Tokenize((Get-Content -Path $NavigationScriptPath -Raw), [ref]$errors)
             $errors.Count | Should -Be 0
         }
 
         It 'should have comment-based help' {
-            $ScriptPath | Should -FileContentMatch '\.SYNOPSIS'
-            $ScriptPath | Should -FileContentMatch '\.DESCRIPTION'
-            $ScriptPath | Should -FileContentMatch '\.EXAMPLE'
+            $NavigationScriptPath | Should -FileContentMatch '\.SYNOPSIS'
+            $NavigationScriptPath | Should -FileContentMatch '\.DESCRIPTION'
+            $NavigationScriptPath | Should -FileContentMatch '\.EXAMPLE'
         }
     }
 
@@ -78,10 +76,10 @@ Describe 'Update-MkDocsNavigation Script Tests' -Tag Unit {
 
     Context 'Get-CategorizedFunctions Tests' {
         BeforeAll {
-            if (Test-Path $ManifestPath) {
-                $categorized = Get-CategorizedFunctions -ManifestPath $ManifestPath
+            if (Test-Path $ModuleManifestPath) {
+                $categorized = Get-CategorizedFunctions -ManifestPath $ModuleManifestPath
             } else {
-                Write-Warning "Manifest not found at: $ManifestPath"
+                Write-Warning "Manifest not found at: $ModuleManifestPath"
                 $categorized = $null
             }
         }

--- a/src/Tests/Unit/Update-MkDocsNavigation.Tests.ps1
+++ b/src/Tests/Unit/Update-MkDocsNavigation.Tests.ps1
@@ -74,10 +74,10 @@ Describe 'Update-MkDocsNavigation Script Tests' -Tag Unit {
         }
     }
 
-    Context 'Get-CategorizedFunctions Tests' {
+    Context 'Get-CategorizedFunction Tests' {
         BeforeAll {
             if (Test-Path $ModuleManifestPath) {
-                $categorized = Get-CategorizedFunctions -ManifestPath $ModuleManifestPath
+                $categorized = Get-CategorizedFunction -ManifestPath $ModuleManifestPath
             } else {
                 Write-Warning "Manifest not found at: $ModuleManifestPath"
                 $categorized = $null
@@ -150,14 +150,14 @@ Describe 'Update-MkDocsNavigation Script Tests' -Tag Unit {
         }
     }
 
-    Context 'New-NavigationYaml Tests' {
+    Context 'ConvertTo-NavigationYaml Tests' {
         BeforeAll {
             $testCategories = @{
                 Customize       = @('Function1', 'Function2')
                 Develop         = @('DevFunction1')
                 'Daily Functions' = @('DailyFunction1', 'DailyFunction2', 'DailyFunction3')
             }
-            $navLines = New-NavigationYaml -CategorizedFunctions $testCategories
+            $navLines = ConvertTo-NavigationYaml -CategorizedFunctions $testCategories
         }
 
         It 'should return an array of strings' {
@@ -236,8 +236,8 @@ markdown_extensions:
         }
 
         It 'should successfully update a test mkdocs.yml file' {
-            $categorized = Get-CategorizedFunctions -ManifestPath $testManifest
-            $navLines = New-NavigationYaml -CategorizedFunctions $categorized
+            $categorized = Get-CategorizedFunction -ManifestPath $testManifest
+            $navLines = ConvertTo-NavigationYaml -CategorizedFunctions $categorized
             $result = Update-MkDocsYaml -MkDocsPath $testMkDocs -NewNavLines $navLines
 
             $result | Should -BeTrue


### PR DESCRIPTION
## Summary
- remove aliases from `FunctionsToExport` and keep command aliases in `AliasesToExport`
- update manifest automation and export tests to distinguish functions from command aliases
- move the MkDocs navigation CI helper to `.github/cicd-scripts`
- fix integration test cleanup to stay inside Pester lifecycle blocks

## Validation
- `Test-ModuleManifest`
- changed-script parser checks
- configured PSScriptAnalyzer checks
- `Invoke-Pester` (`244 passed, 0 failed, 3 skipped`)
- `Invoke-Build -File .\src\PSPreworkout.build.ps1 BuildNoIntegration`