### PR TITLE
🧹 chore(module): update changelog for v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Harden command safety across module operations to reduce risky execution paths.
 
 [*Full Changelog*](https://github.com/SamErde/PSPreworkout/compare/v2.1.0...v2.1.1)
+
 ## [2.1.0] - 2025-12-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- `Get-PowerShellPortable` - Improve PowerShell 5.1 compatibility and safer stream handling.
+- `Get-PowerShellPortable` - Improve PowerShell 5.1 compatibility and make stream handling safer.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2.1.1] - 2026-05-11
+
+### Changed
+
+- `Get-PowerShellPortable` - Improve PowerShell 5.1 compatibility and safer stream handling.
+
+### Security
+
+- Harden command safety across module operations to reduce risky execution paths.
+
+[*Full Changelog*](https://github.com/SamErde/PSPreworkout/compare/v2.1.0...v2.1.1)
+
 ## [2.1.0] - 2025-12-04
 
 ### Added
@@ -478,3 +490,4 @@ This release is focused on enhancements that make the existing functions more us
 [1.9.11]: https://github.com/SamErde/PSPreworkout/tag/v1.9.11
 [2.0.0]: https://github.com/SamErde/PSPreworkout/tag/v2.0.0
 [2.1.0]: https://github.com/SamErde/PSPreworkout/tag/v2.1.0
+[2.1.1]: https://github.com/SamErde/PSPreworkout/tag/v2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Harden command safety across module operations to reduce risky execution paths.
 
 [*Full Changelog*](https://github.com/SamErde/PSPreworkout/compare/v2.1.0...v2.1.1)
-
 ## [2.1.0] - 2025-12-04
 
 ### Added


### PR DESCRIPTION
## Summary
- add the `2.1.1` changelog header dated 2026-05-11
- keep the release notes minimal and user-facing
- add the `2.1.1` release reference link at the bottom

## Notes
- tag `v2.1.1` points to this branch head so the tag and changelog header match